### PR TITLE
Feature // Flter migrated pages by by nodealiaspath

### DIFF
--- a/Migration.Tool.CLI/appsettings.json
+++ b/Migration.Tool.CLI/appsettings.json
@@ -54,6 +54,10 @@
         "ExcludeCodeNames": []
       }
     },
-    "MemberIncludeUserSystemFields": "FirstName|MiddleName|LastName|FullName|UserPassword|PreferredCultureCode|PreferredUICultureCode|UserPrivilegeLevel|UserIsExternal|UserPasswordFormat|LastLogon|UserStartingAliasPath|UserLastModified|UserLastLogonInfo|UserIsHidden|UserIsDomain|UserHasAllowedCultures|UserMFRequired|UserMFSecret|UserMFTimestep|UserNickName|UserSignature|UserURLReferrer|UserCampaign|UserCustomData|UserRegistrationInfo|UserActivationDate|UserActivatedByUserID|UserTimeZoneID|UserAvatarID|UserGender|UserDateOfBirth|UserSettingsUserGUID|UserSettingsUserID|UserWaitingForApproval|UserDialogsConfiguration|UserDescription|UserAuthenticationGUID|UserSkype|UserIM|UserPhone|UserPosition|UserLogActivities|UserPasswordRequestHash|UserInvalidLogOnAttempts|UserInvalidLogOnAttemptsHash|UserPasswordLastChanged|UserAccountLockReason|UserShowIntroductionTile|UserDashboardApplications|UserDismissedSmartTips"
+    "MemberIncludeUserSystemFields": "FirstName|MiddleName|LastName|FullName|UserPassword|PreferredCultureCode|PreferredUICultureCode|UserPrivilegeLevel|UserIsExternal|UserPasswordFormat|LastLogon|UserStartingAliasPath|UserLastModified|UserLastLogonInfo|UserIsHidden|UserIsDomain|UserHasAllowedCultures|UserMFRequired|UserMFSecret|UserMFTimestep|UserNickName|UserSignature|UserURLReferrer|UserCampaign|UserCustomData|UserRegistrationInfo|UserActivationDate|UserActivatedByUserID|UserTimeZoneID|UserAvatarID|UserGender|UserDateOfBirth|UserSettingsUserGUID|UserSettingsUserID|UserWaitingForApproval|UserDialogsConfiguration|UserDescription|UserAuthenticationGUID|UserSkype|UserIM|UserPhone|UserPosition|UserLogActivities|UserPasswordRequestHash|UserInvalidLogOnAttempts|UserInvalidLogOnAttemptsHash|UserPasswordLastChanged|UserAccountLockReason|UserShowIntroductionTile|UserDashboardApplications|UserDismissedSmartTips",
+    "NodeAliasPathPageFilteringMode": "Disabled",
+    "NodeAliasPathPageFilters": [
+      "*"
+    ]
   }
 }

--- a/Migration.Tool.Common/ConfigurationNames.cs
+++ b/Migration.Tool.Common/ConfigurationNames.cs
@@ -65,6 +65,9 @@ public class ConfigurationNames
 
     public const string XbKApiSettings = "XbKApiSettings";
     public const string XbyKApiSettings = "XbyKApiSettings";
+    
+    public const string NodeAliasPathPageFilteringMode = "NodeAliasPathPageFilteringMode";
+    public const string NodeAliasPathPageFilters = "NodeAliasPathPageFilters";
 
     #endregion
 }

--- a/Migration.Tool.Common/MigrationProtocol/HandbookReferences.cs
+++ b/Migration.Tool.Common/MigrationProtocol/HandbookReferences.cs
@@ -30,6 +30,8 @@ public static class HandbookReferences
     public static HandbookReference DataAlreadyExistsInTargetInstance =>
         new("DataAlreadyExistsInTargetInstance");
 
+    public static HandbookReference PageExplicitlyExcludedByAliasPath(string pageAliasPath, string sourcePageGuid) =>
+        new("PageExplicitlyExcludedByAliasPath", $"PageAliasPath={pageAliasPath}, PageGuid={sourcePageGuid}");
     #endregion
 
 

--- a/Migration.Tool.Common/ToolConfiguration.cs
+++ b/Migration.Tool.Common/ToolConfiguration.cs
@@ -13,6 +13,26 @@ public enum AutofixEnum
     Error
 }
 
+/// <summary>
+///     Filtering mode enum
+/// </summary>
+/// <remarks>The enum value names are used verbatim in json configuration, so any changes will need to be coordinated with configs.</remarks>
+public enum FilteringModeEnum
+{
+    /// <summary>
+    /// Filtering disabled - don't apply the filtering rules in any way.
+    /// </summary>
+    Disabled,
+    /// <summary>
+    /// "Include" filtering mode - whitelist behavior; processing should be applied only to objects that match the filter.
+    /// </summary>
+    Include,
+    /// <summary>
+    /// "Exclude" filtering mode - blacklist behavior; don't migrate/process the items that match the filter.
+    /// </summary>
+    Exclude
+}
+
 public class ToolConfiguration
 {
     #region Path to CMS dir of source instance
@@ -60,6 +80,12 @@ public class ToolConfiguration
 
     [ConfigurationKeyName(ConfigurationNames.ConvertClassesToContentHub)]
     public string? ConvertClassesToContentHub { get; set; }
+
+    [ConfigurationKeyName(ConfigurationNames.NodeAliasPathPageFilteringMode)]
+    public FilteringModeEnum NodeAliasPathPageFilteringMode { get; set; } = FilteringModeEnum.Disabled;
+    
+    [ConfigurationKeyName(ConfigurationNames.NodeAliasPathPageFilters)]
+    public string[] NodeAliasPathPageFilters { get; set; } = [];
 
     public IReadOnlySet<string> ClassNamesCreateReusableSchema => classNamesCreateReusableSchema ??= new HashSet<string>(
         (CreateReusableFieldSchemaForClasses?.Split(new[] { ',', ';', '|' }, StringSplitOptions.RemoveEmptyEntries) ?? []).Select(x => x.Trim()),


### PR DESCRIPTION
Implements whitelist/blacklist filtering of the pages during migration based on the node alias path rules defined in the configuration.

Filtering rules support simple wildcards, as implemented by `FileSystemName.MatchesSimpleExpression()` method.

---
### Motivation

Which issue does this fix? Fixes #`issue number`

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
